### PR TITLE
XCodeColorsの設定を追加

### DIFF
--- a/QiitaMeter/Controllers/JANBaseViewController.m
+++ b/QiitaMeter/Controllers/JANBaseViewController.m
@@ -16,11 +16,17 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    LogBlue(@"%s line:%d", __PRETTY_FUNCTION__, __LINE__);
 }
 
 - (void)didReceiveMemoryWarning {
     [super didReceiveMemoryWarning];
     
+}
+
+- (void)dealloc
+{
+    LogBlue(@"%s line:%d", __PRETTY_FUNCTION__, __LINE__);
 }
 
 

--- a/QiitaMeter/Supporting Files/QiitaMeter_Prefix.pch
+++ b/QiitaMeter/Supporting Files/QiitaMeter_Prefix.pch
@@ -18,10 +18,20 @@
 #import "GAIDictionaryBuilder.h"
 #import "GAIFields.h"
 
+
 #endif
 
 #define GOOGLE_ANALYTICS_ID @"UA-58914941-1"
 
+
+#define XCODE_COLORS_ESCAPE @"\033["
+
+#define XCODE_COLORS_RESET_FG  XCODE_COLORS_ESCAPE @"fg;" // Clear any foreground color
+#define XCODE_COLORS_RESET_BG  XCODE_COLORS_ESCAPE @"bg;" // Clear any background color
+#define XCODE_COLORS_RESET     XCODE_COLORS_ESCAPE @";"   // Clear any foreground or backgr
+
+#define LogBlue(frmt, ...) NSLog((XCODE_COLORS_ESCAPE @"fg0,0,255;" frmt XCODE_COLORS_RESET), ##__VA_ARGS__)
+#define LogRed(frmt, ...) NSLog((XCODE_COLORS_ESCAPE @"fg255,0,0;" frmt XCODE_COLORS_RESET), ##__VA_ARGS__)
 
 
 #endif


### PR DESCRIPTION
### 概要

NSLogの代わりに、`LogRed(@"")`とかで、色付きログを出せる様にした。

![2015-03-15 15 50 23](https://cloud.githubusercontent.com/assets/1381585/6654986/0bf389c2-cb2b-11e4-9f6c-c45ffa7e6b53.png)

↓のXCodeプラグイン入れる必要あり。
https://github.com/robbiehanson/XcodeColors
